### PR TITLE
Include HDP hadoop version in the jar name

### DIFF
--- a/bigquery/bigquery-hadoop2.pom.xml
+++ b/bigquery/bigquery-hadoop2.pom.xml
@@ -32,7 +32,7 @@
   <description>
     Hadoop 2 MapReduce input and output formats for use with BigQuery
   </description>
-  <version>0.12.1-hadoop2</version>
+  <version>0.12.1-${hadoop.two.version}</version>
 
   <dependencies>
     <dependency>

--- a/gcs/gcs-hadoop2.pom.xml
+++ b/gcs/gcs-hadoop2.pom.xml
@@ -32,7 +32,7 @@
   <description>
     An implementation of org.apache.hadoop.fs.FileSystem targeting Google Cloud Storage
   </description>
-  <version>1.8.1-hadoop2</version>
+  <version>1.8.1-${hadoop.two.version}</version>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,9 +94,9 @@
     <bigdataoss.util.version>1.8.1</bigdataoss.util.version>
     <bigdataoss.gcsio.version>1.8.1</bigdataoss.gcsio.version>
     <bigdataoss.util-hadoop.one.version>1.8.1-hadoop1</bigdataoss.util-hadoop.one.version>
-    <bigdataoss.util-hadoop.two.version>1.8.1-hadoop2</bigdataoss.util-hadoop.two.version>
+    <bigdataoss.util-hadoop.two.version>1.8.1-${hadoop.two.version}</bigdataoss.util-hadoop.two.version>
     <bigdataoss.gcs.hadoop.one.version>1.8.1-hadoop1</bigdataoss.gcs.hadoop.one.version>
-    <bigdataoss.gcs.hadoop.two.version>1.8.1-hadoop2</bigdataoss.gcs.hadoop.two.version>
+    <bigdataoss.gcs.hadoop.two.version>1.8.1-${hadoop.two.version}</bigdataoss.gcs.hadoop.two.version>
 
     <!-- Keep in sync with Hadoop dependencies -->
     <apache.avro.version>1.7.7</apache.avro.version>

--- a/util-hadoop/util-hadoop-hadoop2.pom.xml
+++ b/util-hadoop/util-hadoop-hadoop2.pom.xml
@@ -28,7 +28,7 @@
 
   <packaging>jar</packaging>
   <artifactId>util-hadoop</artifactId>
-  <version>1.8.1-hadoop2</version>
+  <version>1.8.1-${hadoop.two.version}</version>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Changes the generated jar name to include the full HDP version.
e.g.
Before the patch: gcs-connector-1.8.1-hadoop2-shaded.jar
After the patch: gcs-connector-1.8.1-2.7.3.2.6.5.0-259-shaded.jar