### PR TITLE
HWX: Change default version log line to DEBUG level

### DIFF
--- a/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
+++ b/gcs/src/main/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBase.java
@@ -639,7 +639,7 @@ public abstract class GoogleHadoopFileSystemBase extends FileSystem
     VERSION =
         PropertyUtil.getPropertyOrDefault(
             GoogleHadoopFileSystemBase.class, PROPERTIES_FILE, VERSION_PROPERTY, UNKNOWN_VERSION);
-    LOG.info("GHFS version: {}", VERSION);
+    LOG.debug("GHFS version: {}", VERSION);
     GHFS_ID = String.format("GHFS/%s", VERSION);
   }
 


### PR DESCRIPTION
This changes a LOG line to DEBUG level, whcih would otherwise print a message on each invocation of hadoop (irrespective of whether gcs is used or not), and causes test failures.