### PR TITLE
Add Hadoop File System extended attributes support.

### DIFF
--- a/gcs/CHANGES.txt
+++ b/gcs/CHANGES.txt
@@ -1,3 +1,4 @@
+Backport Add Hadoop File System extended attributes support.
 1.9.10 - 2018-11-01
 
   1. Use Hadoop `CredentialProvider` API to retrieve proxy credentials.

--- a/gcs/pom.xml
+++ b/gcs/pom.xml
@@ -233,6 +233,7 @@
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
           <execution>
+            <id>add-source</id>
             <phase>generate-sources</phase>
             <goals>
               <goal>add-source</goal>
@@ -240,6 +241,18 @@
             <configuration>
               <sources>
                 <source>src/main/${hadoop.identifier}/java</source>
+              </sources>
+            </configuration>
+          </execution>
+          <execution>
+            <id>add-test-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/test/${hadoop.identifier}/java</source>
               </sources>
             </configuration>
           </execution>

--- a/gcs/src/main/hadoop2/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBaseSpecific.java
+++ b/gcs/src/main/hadoop2/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBaseSpecific.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.hadoop.fs.gcs;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
@@ -26,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Progressable;
 
@@ -81,4 +83,17 @@ abstract class GoogleHadoopFileSystemBaseSpecific extends FileSystem {
         blockSize,
         progress);
   }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setXAttr(Path path, String name, byte[] value, EnumSet<XAttrSetFlag> flags)
+      throws IOException {
+    checkArgument(flags != null && !flags.isEmpty(), "flags should not be null or empty");
+    boolean create = flags.contains(XAttrSetFlag.CREATE);
+    boolean replace = flags.contains(XAttrSetFlag.REPLACE);
+    setXAttrInternal(path, name, value, create, replace);
+  }
+
+  abstract void setXAttrInternal(
+      Path path, String name, byte[] value, boolean create, boolean replace) throws IOException;
 }

--- a/gcs/src/main/hadoop3/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBaseSpecific.java
+++ b/gcs/src/main/hadoop3/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemBaseSpecific.java
@@ -14,6 +14,7 @@
 
 package com.google.cloud.hadoop.fs.gcs;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
@@ -26,6 +27,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.XAttrSetFlag;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.util.Progressable;
 
@@ -81,4 +83,17 @@ abstract class GoogleHadoopFileSystemBaseSpecific extends FileSystem {
         blockSize,
         progress);
   }
+
+  /** {@inheritDoc} */
+  @Override
+  public void setXAttr(Path path, String name, byte[] value, EnumSet<XAttrSetFlag> flags)
+      throws IOException {
+    checkArgument(flags != null && !flags.isEmpty(), "flags should not be null or empty");
+    boolean create = flags.contains(XAttrSetFlag.CREATE);
+    boolean replace = flags.contains(XAttrSetFlag.REPLACE);
+    setXAttrInternal(path, name, value, create, replace);
+  }
+
+  abstract void setXAttrInternal(
+      Path path, String name, byte[] value, boolean create, boolean replace) throws IOException;
 }

--- a/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationHadoop2Test.java
+++ b/gcs/src/test/java/com/google/cloud/hadoop/fs/gcs/GoogleHadoopFileSystemIntegrationHadoop2Test.java
@@ -1,0 +1,216 @@
+package com.google.cloud.hadoop.fs.gcs;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertThrows;
+
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystem;
+import com.google.cloud.hadoop.gcsio.GoogleCloudStorageFileSystemIntegrationTest;
+import com.google.cloud.hadoop.gcsio.StorageResourceId;
+import com.google.cloud.hadoop.gcsio.UpdatableItemInfo;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.net.URI;
+import java.util.AbstractMap;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.XAttrSetFlag;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class GoogleHadoopFileSystemIntegrationHadoop2Test {
+
+  private static HadoopFileSystemIntegrationHelper ghfsHelper;
+  private static FileSystem ghfs;
+
+  @BeforeClass
+  public static void setup() throws Throwable {
+    GoogleHadoopFileSystemIntegrationTest.storageResource.before();
+    ghfsHelper = GoogleHadoopFileSystemIntegrationTest.ghfsHelper;
+    ghfs = GoogleHadoopFileSystemIntegrationTest.ghfs;
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    ghfs = null;
+    ghfsHelper = null;
+    GoogleHadoopFileSystemIntegrationTest.storageResource.after();
+  }
+
+  @Test
+  public void getXAttr_nonExistentAttr() throws Exception {
+    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
+    ghfsHelper.writeFile(filePath, "obj-test-get-xattr", 1, /* overwrite= */ false);
+
+    ghfs.setXAttr(filePath, "test-xattr-some", "test-xattr-value".getBytes(UTF_8));
+
+    assertThat(ghfs.getXAttr(filePath, "test-xattr-non-existent")).isNull();
+    assertThat(ghfs.getXAttrs(filePath, ImmutableList.of("test-xattr-non-existent"))).isEmpty();
+
+    // Cleanup.
+    assertThat(ghfs.delete(filePath, true)).isTrue();
+  }
+
+  @Test
+  public void getXAttr_nonGhfsMetadata() throws Exception {
+    GoogleCloudStorageFileSystem gcsFs = ((GoogleHadoopFileSystem) ghfs).getGcsFs();
+    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
+
+    ghfsHelper.writeFile(filePath, "obj-test-get-xattr-extra", 1, /* overwrite= */ false);
+
+    UpdatableItemInfo updateInfo =
+        new UpdatableItemInfo(
+            StorageResourceId.fromObjectName(filePath.toString()),
+            ImmutableMap.of("non-ghfs-xattr-key", "non-ghfs-xattr-value".getBytes(UTF_8)));
+    gcsFs.getGcs().updateItems(ImmutableList.of(updateInfo));
+
+    ghfs.setXAttr(filePath, "test-xattr-some", "test-xattr-value".getBytes(UTF_8));
+
+    assertThat(toStringValuesMap(gcsFs.getFileInfo(filePath.toUri()).getAttributes()))
+        .containsExactly(
+            "non-ghfs-xattr-key", "non-ghfs-xattr-value",
+            "GHFS_XATTR_test-xattr-some", "test-xattr-value");
+    assertThat(toStringValuesMap(ghfs.getXAttrs(filePath)))
+        .containsExactly("test-xattr-some", "test-xattr-value");
+
+    // Cleanup.
+    assertThat(ghfs.delete(filePath, true)).isTrue();
+  }
+
+  @Test
+  public void setXAttr() throws Exception {
+    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
+    ghfsHelper.writeFile(filePath, "obj-test-set-xattr", 1, /* overwrite= */ false);
+
+    ghfs.setXAttr(filePath, "test-xattr-some", "test-xattr-value".getBytes(UTF_8));
+    ghfs.setXAttr(filePath, "test-xattr-null", null);
+    ghfs.setXAttr(filePath, "test-xattr-empty", new byte[0]);
+
+    assertThat(ghfs.listXAttrs(filePath))
+        .containsExactly("test-xattr-some", "test-xattr-null", "test-xattr-empty");
+    assertThat(ghfs.getXAttr(filePath, "test-xattr-some"))
+        .isEqualTo("test-xattr-value".getBytes(UTF_8));
+    assertThat(ghfs.getXAttr(filePath, "test-xattr-null")).isEmpty();
+    assertThat(ghfs.getXAttr(filePath, "test-xattr-empty")).isEmpty();
+    assertThat(toStringValuesMap(ghfs.getXAttrs(filePath)))
+        .containsExactly(
+            "test-xattr-some", "test-xattr-value",
+            "test-xattr-null", "",
+            "test-xattr-empty", "");
+    assertThat(
+            toStringValuesMap(
+                ghfs.getXAttrs(
+                    filePath,
+                    ImmutableList.of("test-xattr-empty", "test-xattr-some", "test-xattr-null"))))
+        .containsExactly(
+            "test-xattr-some", "test-xattr-value",
+            "test-xattr-null", "",
+            "test-xattr-empty", "");
+
+    // Cleanup.
+    assertThat(ghfs.delete(filePath, true)).isTrue();
+  }
+
+  @Test
+  public void setXAttr_replace() throws Exception {
+    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
+    ghfsHelper.writeFile(filePath, "obj-test-set-xattr-replace", 1, /* overwrite= */ false);
+
+    ghfs.setXAttr(filePath, "test-xattr-some", "test-xattr-value".getBytes(UTF_8));
+
+    assertThat(ghfs.getXAttr(filePath, "test-xattr-some"))
+        .isEqualTo("test-xattr-value".getBytes(UTF_8));
+
+    ghfs.setXAttr(filePath, "test-xattr-some", "test-xattr-value-new".getBytes(UTF_8));
+
+    assertThat(ghfs.getXAttr(filePath, "test-xattr-some"))
+        .isEqualTo("test-xattr-value-new".getBytes(UTF_8));
+
+    // Cleanup.
+    assertThat(ghfs.delete(filePath, true)).isTrue();
+  }
+
+  @Test
+  public void setXAttr_create_fail() throws Exception {
+    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
+    ghfsHelper.writeFile(filePath, "obj-test-set-xattr-create-fail", 1, /* overwrite= */ false);
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                ghfs.setXAttr(
+                    filePath, "test-key", "val".getBytes(UTF_8), EnumSet.of(XAttrSetFlag.REPLACE)));
+
+    assertThat(e).hasMessageThat().startsWith("CREATE flag must be set to create XAttr");
+
+    // Cleanup.
+    assertThat(ghfs.delete(filePath, true)).isTrue();
+  }
+
+  @Test
+  public void setXAttr_replace_fail() throws Exception {
+    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
+    ghfsHelper.writeFile(filePath, "obj-test-set-xattr-replace-fail", 1, /* overwrite= */ false);
+
+    ghfs.setXAttr(filePath, "test-key", "value".getBytes(UTF_8));
+
+    IOException e =
+        assertThrows(
+            IOException.class,
+            () ->
+                ghfs.setXAttr(
+                    filePath, "test-key", "new".getBytes(UTF_8), EnumSet.of(XAttrSetFlag.CREATE)));
+    assertThat(e).hasMessageThat().startsWith("REPLACE flag must be set to update XAttr");
+
+    // Cleanup.
+    assertThat(ghfs.delete(filePath, true)).isTrue();
+  }
+
+  @Test
+  public void removeXAttr() throws Exception {
+    URI fileUri = GoogleCloudStorageFileSystemIntegrationTest.getTempFilePath();
+    Path filePath = ghfsHelper.castAsHadoopPath(fileUri);
+    ghfsHelper.writeFile(filePath, "obj-test-remove-xattr", 1, /* overwrite= */ false);
+
+    ghfs.setXAttr(filePath, "test-xattr-some", "test-xattr-value-1".getBytes(UTF_8));
+    ghfs.setXAttr(filePath, "test-xattr-to-remove", "test-xattr-value-2".getBytes(UTF_8));
+
+    assertThat(toStringValuesMap(ghfs.getXAttrs(filePath)))
+        .containsExactly(
+            "test-xattr-some", "test-xattr-value-1",
+            "test-xattr-to-remove", "test-xattr-value-2");
+
+    ghfs.removeXAttr(filePath, "test-xattr-to-remove");
+
+    assertThat(ghfs.getXAttr(filePath, "test-xattr-to-remove")).isNull();
+    assertThat(toStringValuesMap(ghfs.getXAttrs(filePath)))
+        .containsExactly("test-xattr-some", "test-xattr-value-1");
+
+    // Cleanup.
+    assertThat(ghfs.delete(filePath, true)).isTrue();
+  }
+
+  private static Map<String, String> toStringValuesMap(Map<String, byte[]> map) {
+    return map.entrySet().stream()
+        .map(
+            e ->
+                new AbstractMap.SimpleEntry<>(
+                    e.getKey(), e.getValue() == null ? null : new String(e.getValue(), UTF_8)))
+        .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), Map::putAll);
+  }
+}

--- a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/CreateFileOptions.java
+++ b/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/CreateFileOptions.java
@@ -27,7 +27,7 @@ public class CreateFileOptions {
   public static final ImmutableMap<String, byte[]> EMPTY_ATTRIBUTES = ImmutableMap.of();
   public static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
   public static final CreateFileOptions DEFAULT =
-      new CreateFileOptions(true, DEFAULT_CONTENT_TYPE, EMPTY_ATTRIBUTES);
+      new CreateFileOptions(/* overwriteExisting= */ true, DEFAULT_CONTENT_TYPE, EMPTY_ATTRIBUTES);
 
   private final boolean overwriteExisting;
   private final String contentType;

--- a/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
+++ b/gcsio/src/test/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageFileSystemIntegrationTest.java
@@ -75,7 +75,7 @@ public class GoogleCloudStorageFileSystemIntegrationTest {
   // hack to make tests pass until JUnit 4.13 regression will be fixed:
   // https://github.com/junit-team/junit4/issues/1509
   // TODO: refactor or delete this hack
-  protected static class NotInheritableExternalResource extends ExternalResource {
+  public static class NotInheritableExternalResource extends ExternalResource {
     private final Class<?> testClass;
 
     public NotInheritableExternalResource(Class<?> testClass) {


### PR DESCRIPTION
Tested by by building the gcs connector shaded jar locally and putting it into hadoop packaged local distribution. Then ran the command which was failing for the customer. 
hadoop fs -Dgoogle.cloud.auth.service.account.enable=true  -Dgoogle.cloud.auth.service.account.json.keyfile=gcs_service_account_keyfile.json 
-setfattr -n foo -v bar gs://2bc51c33-2800-0b09-0137-4ba34f822fc6/test.txt 